### PR TITLE
Rename package to remove -readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# remark-preset-lint-origami-component-readme
+# remark-preset-lint-origami-component
 
 remark preset to configure `remark-lint` with settings that enforce the rules
 and suggestions in the [origami component specification](https://origami.ft.com/spec/v1/components/#readme).
@@ -6,7 +6,7 @@ and suggestions in the [origami component specification](https://origami.ft.com/
 ## installation
 
 ```sh
-npm install remark-preset-lint-origami-component-readme
+npm install remark-preset-lint-origami-component
 ```
 
 ## use
@@ -20,5 +20,5 @@ module.exports.plugins = [require("remark-preset-lint-origami-component")]
 Or use it directly through [the remark cli](https://github.com/remarkjs/remark/tree/master/packages/remark-cli):
 
 ```sh
-remark -u preset-lint-consistent README.md
+remark -u preset-lint-origami-component README.md
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "remark-preset-lint-origami-component-readme",
+	"name": "remark-preset-lint-origami-component",
 	"version": "1.0.0",
 	"description": "remark lint preset for Origami component README.md",
 	"main": "index.js",


### PR DESCRIPTION
at the moment it only lints the readme, but maybe it will also lint the MIGRATION.md at some point