### PR TITLE
Improve licence linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "remark-preset-lint-origami-component",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "remark-preset-lint-origami-component",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "remark lint preset for Origami component README.md",
 	"main": "index.js",
 	"scripts": {

--- a/rules/readme-has-licence.js
+++ b/rules/readme-has-licence.js
@@ -12,9 +12,10 @@ function readmeHasLicence(tree, file) {
 	}
 	let licenceHeading = find(tree, n => {
 		if (n.type == "heading" && n.depth == 2) {
-			let text = toString(n).trim().toLowerCase()
+			let h2 = n
+			let text = toString(h2).trim().toLowerCase()
 			if (text == "license") {
-				file.message("Licence should be spelt 'licence', not 'license'")
+				file.message("Licence should be spelt 'licence', not 'license'", h2)
 				return true
 			}
 			return text == "licence"

--- a/rules/readme-has-licence.js
+++ b/rules/readme-has-licence.js
@@ -22,7 +22,9 @@ function readmeHasLicence(tree, file) {
 	})
 
 	if (!licenceHeading) {
-		file.message("Readme should have a 'Licence' section, with a valid licence")
+		file.message(
+			"Readme should have an h2 'Licence' section, with a valid licence"
+		)
 		return
 	}
 


### PR DESCRIPTION
* add "h2" to the error message so hopefully people notice if the problem is they are using an h1 or an h3 for licence
* when licence is there but spelt incorrectly, make that error appear on the misspelt node (before it appeared at 0:0-0:0