### PR TITLE
Add new rule `readme-has-general-usage`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,4 +44,5 @@ module.exports.plugins = [
 	require("./rules/readme-has-short-description"),
 	require("./rules/readme-has-toc"),
 	require("./rules/readme-has-licence"),
+	require("./rules/readme-has-general-usage"),
 ]

--- a/rules/readme-has-general-usage.js
+++ b/rules/readme-has-general-usage.js
@@ -1,0 +1,42 @@
+let rule = require("unified-lint-rule")
+let walk = require("unist-util-visit")
+let { join } = require("path")
+let { existsSync, readFileSync } = require("fs")
+
+/**
+ * Has a link to general component usage information:
+ * https://origami.ft.com/docs/components
+ *
+ * @param {import("mdast").Root} tree
+ */
+function readmeHasGeneralUsage(tree, file) {
+    if (file.basename.toLowerCase() != "readme.md") {
+        return
+    }
+
+    const generalUsageLink = 'https://origami.ft.com/docs/components';
+
+    let hasGeneralUsageLink = false;
+    walk(tree, 'link' , function (node) {
+        // Check includes to allow anchor links to more specific sections.
+        if (node.url && node.url.includes(generalUsageLink)) {
+            hasGeneralUsageLink = true;
+            return;
+        }
+    });
+
+    if (hasGeneralUsageLink) {
+        return;
+    }
+
+    file.message(
+        `Readme should have a link to general component usage ` +
+        `"${generalUsageLink}". Usually under a h2 heading "Usage" after ` +
+        `the table of contents`
+    )
+}
+
+module.exports = rule(
+    "remark-lint:origami-component/readme-has-general-usage",
+    readmeHasGeneralUsage
+)

--- a/rules/readme-has-general-usage.js
+++ b/rules/readme-has-general-usage.js
@@ -10,33 +10,33 @@ let { existsSync, readFileSync } = require("fs")
  * @param {import("mdast").Root} tree
  */
 function readmeHasGeneralUsage(tree, file) {
-    if (file.basename.toLowerCase() != "readme.md") {
-        return
-    }
+	if (file.basename.toLowerCase() != "readme.md") {
+		return
+	}
 
-    const generalUsageLink = 'https://origami.ft.com/docs/components';
+	const generalUsageLink = "https://origami.ft.com/docs/components";
 
-    let hasGeneralUsageLink = false;
-    walk(tree, 'link' , function (node) {
-        // Check includes to allow anchor links to more specific sections.
-        if (node.url && node.url.includes(generalUsageLink)) {
-            hasGeneralUsageLink = true;
-            return;
-        }
-    });
+	let hasGeneralUsageLink = false;
+	walk(tree, "link" , function (node) {
+		// Check includes to allow anchor links to more specific sections.
+		if (node.url && node.url.includes(generalUsageLink)) {
+			hasGeneralUsageLink = true;
+			return;
+		}
+	});
 
-    if (hasGeneralUsageLink) {
-        return;
-    }
+	if (hasGeneralUsageLink) {
+		return;
+	}
 
-    file.message(
-        `Readme should have a link to general component usage ` +
-        `"${generalUsageLink}". Usually under a h2 heading "Usage" after ` +
-        `the table of contents`
-    )
+	file.message(
+		`Readme should have a link to general component usage ` +
+		`"${generalUsageLink}". Usually under a h2 heading "Usage" after ` +
+		`the table of contents`
+	)
 }
 
 module.exports = rule(
-    "remark-lint:origami-component/readme-has-general-usage",
-    readmeHasGeneralUsage
+	"remark-lint:origami-component/readme-has-general-usage",
+	readmeHasGeneralUsage
 )

--- a/test/invalid/invalid-missing-general-usage/README.md
+++ b/test/invalid/invalid-missing-general-usage/README.md
@@ -1,4 +1,6 @@
-# o-table
+# table-of-contents-no-heading [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](#licence)
+
+a valid origami readme
 
 - [Usage](#usage)
 - [Markup](#markup)
@@ -8,11 +10,15 @@
 	- [Expander](#expander)
 	- [Additional Markup](#additional-markup)
 - [Sass](#sass)
-- [JavaScript](#javascript) - [Sorting](#sorting) - [Filtering](#filtering) - [Events](#events)
+- [JavaScript](#javascript)
+	- [Filtering](#filtering)
+	- [Sorting](#sorting)
+	- [Dynamic rows](#dynamic-rows)
+	- [Events](#events)
 - [Troubleshooting](#troubleshooting)
 - [Migration](#migration)
 - [Contact](#contact)
-- [Chungus](#chungus)
+- [Licence](#licence)
 
 ## Usage
 
@@ -20,7 +26,7 @@
 
 ## Markup
 
-### o-table
+### Basic table
 
 Add an `o-table` class to any table you wish to apply the styles to:
 
@@ -464,9 +470,7 @@ If rows are added or removed dynamically after the table is initialised call `up
 The following events are fired by `o-table`.
 
 - `oTable.ready`
-
-* `oTable.sorting`
-
+- `oTable.sorting`
 - `oTable.sorted`
 
 #### oTable.ready
@@ -550,14 +554,10 @@ Known issues:
 | ╳ deprecated |       2       |        2.0         |                          N/A                          |
 | ╳ deprecated |       1       |        1.7         |                          N/A                          |
 
-## Hefty hungus
-
-Hello
-
 ## Contact
 
 If you have any questions or comments about this component, or need help using it, please either [raise an issue](https://github.com/Financial-Times/o-table/issues), visit [#origami-support](https://financialtimes.slack.com/messages/origami-support/) or email [Origami Support](mailto:origami-support@ft.com).
 
 ## Licence
 
-I eat the cheese
+This software is published by the Financial Times under the [MIT licence](http://opensource.org/licenses/MIT).

--- a/test/invalid/invalid-missing-general-usage/bower.json
+++ b/test/invalid/invalid-missing-general-usage/bower.json
@@ -1,0 +1,1 @@
+{"name": "table-of-contents-no-heading"}

--- a/test/invalid/invalid-toc-with-heading/README.md
+++ b/test/invalid/invalid-toc-with-heading/README.md
@@ -4,9 +4,14 @@ this one has an invalid toc with a heading
 
 ## Table of Contents
 
+- [Usage](#usage)
 - [Markup](#markup)
 - [Wrong monkey](#404-no-such-monkey)
 - [Licence](#license)
+
+## Usage
+
+[Include components](https://origami.ft.com/docs/components/#including-origami-components-in-your-project).
 
 ## Markup
 

--- a/test/invalid/invalid-toc-without-heading/README.md
+++ b/test/invalid/invalid-toc-without-heading/README.md
@@ -2,9 +2,14 @@
 
 this one has an invalid toc without a "table of contents" heading
 
+- [Usage](#usage)
 - [Markup](#markup)
 - [Wrong monkey](#404-no-such-monkey)
 - [Licence](#license)
+
+## Usage
+
+[Include components](https://origami.ft.com/docs/components/#including-origami-components-in-your-project).
 
 ## Markup
 

--- a/test/valid/table-of-contents-heading/README.md
+++ b/test/valid/table-of-contents-heading/README.md
@@ -4,6 +4,7 @@ a valid origami readme
 
 ## Table of Contents
 
+- [Usage](#usage)
 - [Markup](#markup)
 	- [Basic Table](#basic-table)
 	- [Disable sort](#disable-sort)
@@ -20,6 +21,10 @@ a valid origami readme
 - [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
+
+## Usage
+
+Check out [how to include Origami components in your project](https://origami.ft.com/docs/components/#including-origami-components-in-your-project) to get started with `o-table`.
 
 ## Markup
 

--- a/test/valid/table-of-contents-no-heading/README.md
+++ b/test/valid/table-of-contents-no-heading/README.md
@@ -2,6 +2,7 @@
 
 a valid origami readme
 
+- [Usage](#usage)
 - [Markup](#markup)
 	- [Basic Table](#basic-table)
 	- [Disable sort](#disable-sort)
@@ -18,6 +19,10 @@ a valid origami readme
 - [Migration](#migration)
 - [Contact](#contact)
 - [Licence](#licence)
+
+## Usage
+
+Check out [how to include Origami components in your project](https://origami.ft.com/docs/components/#including-origami-components-in-your-project) to get started with `o-table`.
 
 ## Markup
 


### PR DESCRIPTION
Check for the presence of a link to general component usage
documentation "https://origami.ft.com/docs/components".

Relates to: https://github.com/Financial-Times/origami/issues/59

Fixes: https://github.com/Financial-Times/remark-preset-lint-origami-component/issues/13