### PR TITLE
Update `automatic-tag-and-release`, consistent with components.

### DIFF
--- a/.github/workflows/automatic-tag-and-release.yml
+++ b/.github/workflows/automatic-tag-and-release.yml
@@ -13,6 +13,7 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }} # Checkout the merged commit
           fetch-depth: 0
       - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* # Get all tags from the origin
+        if: github.event.pull_request.merged # Only run on merged pull-requests
       - uses: Financial-Times/origami-version@v1
         name: Create new version/tag
         if: github.event.pull_request.merged  # Only run on merged pull-requests


### PR DESCRIPTION
I'm wondering if it will somehow help this issue, though
I don't see how it would.
https://github.com/Financial-Times/remark-preset-lint-origami-component/issues/24

Since `fetch-depth: 0` fetches all tags and branches, I wonder
if the step is needed at all
https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches