### PR TITLE
Add publish to npm workflow

### DIFF
--- a/.github/workflows/ publish-to-npm.yml 
+++ b/.github/workflows/ publish-to-npm.yml 
@@ -1,0 +1,21 @@
+name: Publish to npm
+on:
+  release:
+    types: [created]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2.1.4
+      with:
+        node-version: '12.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm ci
+    - name: Get the version
+      id: version
+      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+    - run: npm version --no-git-tag-version ${{ steps.version.outputs.VERSION }}
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `automatic-tag-and-release` workflow creates a GitHub release
based on which of our Github release labels have been applied to
a merged PR, and comments on the PR to say the release has happened.
However it does not actually do the publishing to npm. That means
the last two releases of `remark-preset-lint-origami-component`
were not published to npm but looked as if they were. Including
this PR to try fixing the README name warning in Github:
https://github.com/Financial-Times/remark-preset-lint-origami-component/pull/37