### PR TITLE
update the test workflow to use branch named `main`

### DIFF
--- a/.github/workflows/npm-cit.yml
+++ b/.github/workflows/npm-cit.yml
@@ -5,12 +5,12 @@ name: npm cit
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
-  build:
+  test:
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
we changed the default branch of this project but missed this workflow during that work.